### PR TITLE
Exclude components from Syft that are not part of the built project

### DIFF
--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,11 @@
+# Only the Go backend components are part of the final container image so other components in the monorepo should not be
+# part of any generated SBOM from Syft.
+exclude:
+- ./.github
+- ./ui/**
+- ./sdks/**
+- ./test/**
+- ./**/package.json
+- ./**/package-lock.json
+- ./**/*requirements*.txt
+- ./**/setup.py


### PR DESCRIPTION
This will stop the inapplicable vulnerability reports.