### PR TITLE
[RHOAI 2.8] Backport the syft configuration

### DIFF
--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,11 @@
+# Only the Go backend components are part of the final container image so other components in the monorepo should not be
+# part of any generated SBOM from Syft.
+exclude:
+- ./.github
+- ./ui/**
+- ./sdks/**
+- ./test/**
+- ./**/package.json
+- ./**/package-lock.json
+- ./**/*requirements*.txt
+- ./**/setup.py


### PR DESCRIPTION
This was added to RHOAI 2.21 but not older versions. This will prevent CVEs being in the SBOM of code we don't ship.