### PR TITLE
add linux-m2xlarge/arm64 to build platforms

### DIFF
--- a/.tekton/odh-data-science-pipelines-argo-argoexec-v2-24-pull-request.yaml
+++ b/.tekton/odh-data-science-pipelines-argo-argoexec-v2-24-pull-request.yaml
@@ -46,6 +46,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-m2xlarge/arm64
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-24-pull-request.yaml
+++ b/.tekton/odh-data-science-pipelines-argo-workflowcontroller-v2-24-pull-request.yaml
@@ -46,6 +46,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-m2xlarge/arm64
   - name: image-expires-after
     value: 5d
   pipelineRef:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/RHOAIENG-30798

the idea is that in each PR will show failures which will provide hints on what should be done to support ARM. this will enable a cycle of failure -> fix -> failure -> fix -> success... and will at least show what is not working in the build pipeline.

the comment `/build-konflux` to be used can be found in the pull-request pipeline file (.tekton).