### PR TITLE
feat: Enable konflux build of argo images on ppc64le

### DIFF
--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,6 +1,7 @@
 arches:
   - x86_64
   - aarch64
+  - ppc64le
 contentOrigin:
   repofiles:
     - ubi.repo

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -19,6 +19,23 @@ arches:
     name: mailcap
     evr: 2.1.49-5.el9
   module_metadata: []
+- arch: ppc64le
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/m/mailcap-2.1.49-5.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 35492
+    checksum: sha256:6c880effa119e3eaf709ba6290a4f6e2b7294de64baf19ee84f672a89e732090
+    name: mailcap
+    evr: 2.1.49-5.el9
+    sourcerpm: mailcap-2.1.49-5.el9.src.rpm
+  source:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/m/mailcap-2.1.49-5.el9.src.rpm
+    repoid: ubi-9-for-ppc64le-baseos-source-rpms
+    size: 36955
+    checksum: sha256:34c34987a363c83bc8583167709b988837b1686e7b4d7faabe0247731321792b
+    name: mailcap
+    evr: 2.1.49-5.el9
+  module_metadata: []
 - arch: x86_64
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/mailcap-2.1.49-5.el9.noarch.rpm


### PR DESCRIPTION
This is the test PR to check konflux build of following argo-workflow images on ppc64le.

ds-pipelines-argo-argoexec
ds-pipelines-argo-workflowcontroller
