### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-data-science-pipelines-argo-workflowcontroller-v2-23

### DIFF
--- a/argo-workflowcontroller/Dockerfile.konflux
+++ b/argo-workflowcontroller/Dockerfile.konflux
@@ -31,7 +31,8 @@ FROM registry.redhat.io/ubi9/ubi-minimal@sha256:aca8052836f670988f68139b46ddc6ba
 ARG CI_CONTAINER_VERSION
 
 LABEL com.redhat.component="odh-data-science-pipelines-argo-workflowcontroller-container" \
-      name="managed-open-data-hub/odh-data-science-pipelines-argo-workflowcontroller-rhel8" \
+      name="rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.23::el9" \
       description="Argo Workflow Controller for Argo Workflows used in Data Science Pipelines" \
       summary="odh-data-science-pipelines-argo-workflowcontroller" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
