### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-data-science-pipelines-argo-argoexec-v2-21

### DIFF
--- a/argo-argoexec/Dockerfile.konflux
+++ b/argo-argoexec/Dockerfile.konflux
@@ -31,7 +31,8 @@ FROM registry.redhat.io/ubi9/ubi-minimal@sha256:7c5495d5fad59aaee12abc3cbbd2b283
 ARG CI_CONTAINER_VERSION
 
 LABEL com.redhat.component="odh-data-science-pipelines-argo-argoexec-container" \
-      name="managed-open-data-hub/odh-data-science-pipelines-argo-argoexec-rhel8" \
+      name="rhoai/odh-data-science-pipelines-argo-argoexec-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.21::el9" \
       description="Argo Executor for Argo Workflows used in Data Science Pipelines" \
       summary="odh-data-science-pipelines-argo-argoexec" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
