### PR TITLE
chore: bump Go builders to 1.25.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM golang:1.25-alpine3.22 as builder
+FROM golang:1.25.7-alpine3.22 AS builder
 
 RUN apk update && apk add --no-cache \
     git \

--- a/argo-argoexec/Dockerfile.ODH
+++ b/argo-argoexec/Dockerfile.ODH
@@ -1,6 +1,6 @@
 ARG SOURCE_CODE=.
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7-1771417345 AS builder
 
 # Build args to be used at this step
 ARG SOURCE_CODE

--- a/argo-argoexec/Dockerfile.konflux
+++ b/argo-argoexec/Dockerfile.konflux
@@ -5,7 +5,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:8c5aeac74b4b60dc2e5e44f6b639186b7ec2fec8f0eb9a36d4a32dcf8e255f52 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7-1771417345 AS builder
 
 # Build args to be used at this step
 ARG SOURCE_CODE

--- a/argo-workflowcontroller/Dockerfile.ODH
+++ b/argo-workflowcontroller/Dockerfile.ODH
@@ -1,6 +1,6 @@
 ARG SOURCE_CODE=.
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7-1771417345 AS builder
 
 # Build args to be used at this step
 ARG SOURCE_CODE

--- a/argo-workflowcontroller/Dockerfile.konflux
+++ b/argo-workflowcontroller/Dockerfile.konflux
@@ -6,7 +6,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:8c5aeac74b4b60dc2e5e44f6b639186b7ec2fec8f0eb9a36d4a32dcf8e255f52 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7-1771417345 AS builder
 
 # Build args to be used at this step
 ARG SOURCE_CODE

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v3
 
-go 1.25.5
+go 1.25.7
 
 require (
 	cloud.google.com/go/storage v1.36.0


### PR DESCRIPTION
## Summary
- bump `go.mod` Go version to `1.25.7`
- update builder images to Go `1.25.7` using the required UBI9 go-toolset tag where applicable
- keep non-builder/runtime image stages unchanged

## Test plan
- [ ] CI build passes for argoexec and workflowcontroller images
- [ ] Verify generated images no longer report vulnerabilities fixed in Go 1.25.7

Made with [Cursor](https://cursor.com)