### PR TITLE
fix(security): bump Go builder images for CVE-2025-61726

### DIFF
--- a/argo-argoexec/Dockerfile.konflux
+++ b/argo-argoexec/Dockerfile.konflux
@@ -5,7 +5,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a as builder
 
 # Build args to be used at this step
 ARG SOURCE_CODE

--- a/argo-workflowcontroller/Dockerfile.konflux
+++ b/argo-workflowcontroller/Dockerfile.konflux
@@ -6,7 +6,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a as builder
 
 # Build args to be used at this step
 ARG SOURCE_CODE


### PR DESCRIPTION
## Issue
**CVE-2025-61726** — `net/url` / large URL-encoded forms can drive excessive memory use via `ParseForm`. Fixed in **Go >= 1.25.6** or **>= 1.24.12** ([NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-61726)).

**Resolves Jira:** [RHOAIENG-48614](https://redhat.atlassian.net/browse/RHOAIENG-48614) · [RHOAIENG-48615](https://redhat.atlassian.net/browse/RHOAIENG-48615) (argoexec / workflow-controller, rhel9)

## Summary

- Update **Konflux** builder images only for `argoexec` and `workflow-controller`.
- Pin `registry.access.redhat.com/ubi9/go-toolset:1.25` by digest in:
  - `argo-argoexec/Dockerfile.konflux`
  - `argo-workflowcontroller/Dockerfile.konflux`
- No changes to `go.mod`, root `Dockerfile`, ODH Dockerfiles, CI workflows, or codegen artifacts in this PR.

### Note

- This PR is intentionally scoped to the minimal Konflux remediation path for CVE-2025-61726.
- Broader Go/tooling alignment can be handled separately if needed.