### PR TITLE
chore(ci): noop Dockerfile comment to verify CI health

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,3 +1,4 @@
+# No-op (PR #625): comment-only — same workflow path as PR #623; logic unchanged.
 name: CI
 on:
   push:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,3 +1,4 @@
+# No-op (PR #625): comment-only — same workflow path as PR #623; logic unchanged.
 name: Docs
 
 on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,4 @@
+# No-op (PR #625): comment-only — same workflow path as PR #623; logic unchanged.
 name: Release
 
 on:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 #syntax=docker/dockerfile:1.2
+# No-op (PR #625): same file set as PR #623 — Alpine/golang builder tag unchanged.
 ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ export SHELLOPTS:=$(if $(SHELLOPTS),$(SHELLOPTS):)pipefail:errexit
 
 # NOTE: Please ensure dependencies are synced with the flake.nix file in dev/nix/flake.nix before upgrading
 # any external dependency. There is documentation on how to do this under the Developer Guide
+#
+# No-op (PR #625): same Makefile path as PR #623 — dependency pins unchanged on this branch.
 
 USE_NIX := false
 # https://stackoverflow.com/questions/4122831/disable-make-builtin-rules-and-variables-from-inside-the-make-file

--- a/argo-argoexec/Dockerfile.ODH
+++ b/argo-argoexec/Dockerfile.ODH
@@ -1,5 +1,6 @@
 ARG SOURCE_CODE=.
 
+# No-op (PR #625): same path as PR #623 — UBI go-toolset tag unchanged.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as builder
 
 # Build args to be used at this step

--- a/argo-argoexec/Dockerfile.konflux
+++ b/argo-argoexec/Dockerfile.konflux
@@ -5,6 +5,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
+# No-op (PR #625): same path as PR #623 — digest-pinned builder unchanged.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder
 
 # Build args to be used at this step

--- a/argo-workflowcontroller/Dockerfile.ODH
+++ b/argo-workflowcontroller/Dockerfile.ODH
@@ -1,5 +1,6 @@
 ARG SOURCE_CODE=.
 
+# No-op (PR #625): same path as PR #623 — UBI go-toolset tag unchanged.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as builder
 
 # Build args to be used at this step

--- a/argo-workflowcontroller/Dockerfile.konflux
+++ b/argo-workflowcontroller/Dockerfile.konflux
@@ -6,6 +6,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
+# No-op (PR #625): same path as PR #623 — digest-pinned builder unchanged.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder
 
 # Build args to be used at this step

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/argoproj/argo-workflows/v3
 
+// No-op (PR #625 control branch): touches same paths as PR #623 — go directive unchanged here.
+
 go 1.24.4
 
 require (


### PR DESCRIPTION
Triggers Docker image build and e2e-tests path filters without functional change. Use vs security/image bump PRs to tell infra regressions from code changes.

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
