### PR TITLE
chore: bump go toolset

### DIFF
--- a/argo-workflowcontroller/Dockerfile.konflux
+++ b/argo-workflowcontroller/Dockerfile.konflux
@@ -6,7 +6,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:b2c0898987b688a95f4d2f38abdfd929f45903948831783153019ab749495c72 as builder
 
 # Build args to be used at this step
 ARG SOURCE_CODE


### PR DESCRIPTION
bump go toolset for 3.5-ea.2 to fix attached [build failure](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5-ea-2/pipelineruns/odh-data-science-pipelines-argo-workflowcontroller-v3-5-eavjzp5) with logs attached:

```
go: go.mod requires go >= 1.26 (running go 1.24.6; GOTOOLCHAIN=local)
Error: building at STEP "RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build . /cachi2/cachi2.env &&     GIT_COMMIT=${GIT_COMMIT} GIT_TAG=${GIT_TAG} GIT_TREE_STATE=${GIT_TREE_STATE} CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build  -tags strictfipsruntime -v  -o dist/workflow-controller ./cmd/workflow-controller": exit status 1
```